### PR TITLE
Adding an Important Note

### DIFF
--- a/modules/ROOT/pages/to-publish-assets-maven.adoc
+++ b/modules/ROOT/pages/to-publish-assets-maven.adoc
@@ -194,6 +194,9 @@ https://anypoint.mulesoft.com/accounts/api/profile
 </settings>
 ----
 
+[IMPORTANT]
+`<username>` needs to be kept as in the example given that is used by the platform to identify the token will be used. You need to set your token in `<password>ACCESS_TOKEN</password>` tag.
+
 == Consume an Exchange Asset with Maven
 
 Add the asset's groupID, artifactID, and version to the `dependencies` section of your project's pom.xml file,

--- a/modules/ROOT/pages/to-publish-assets-maven.adoc
+++ b/modules/ROOT/pages/to-publish-assets-maven.adoc
@@ -195,7 +195,7 @@ https://anypoint.mulesoft.com/accounts/api/profile
 ----
 
 [IMPORTANT]
-The value in `<username>` is a literal, don't change it. The value tells the platform that you're using a token. Set your token in <password>ACCESS_TOKEN</password>.
+The value in `<username>` is a literal, don't change it. The value tells the platform that you're using a token. Set your token in `<password>ACCESS_TOKEN</password>`.
 
 == Consume an Exchange Asset with Maven
 

--- a/modules/ROOT/pages/to-publish-assets-maven.adoc
+++ b/modules/ROOT/pages/to-publish-assets-maven.adoc
@@ -195,7 +195,7 @@ https://anypoint.mulesoft.com/accounts/api/profile
 ----
 
 [IMPORTANT]
-`<username>` needs to be kept as in the example given that is used by the platform to identify the token will be used. You need to set your token in `<password>ACCESS_TOKEN</password>` tag.
+Do not change <username>~~~TOKEN~~~</username>, because that value tells the platform that you're using a token. Set your token in <password>ACCESS_TOKEN</password>.
 
 == Consume an Exchange Asset with Maven
 

--- a/modules/ROOT/pages/to-publish-assets-maven.adoc
+++ b/modules/ROOT/pages/to-publish-assets-maven.adoc
@@ -195,7 +195,7 @@ https://anypoint.mulesoft.com/accounts/api/profile
 ----
 
 [IMPORTANT]
-Do not change <username>~~~TOKEN~~~</username>, because that value tells the platform that you're using a token. Set your token in <password>ACCESS_TOKEN</password>.
+Do not change `<username>~~~TOKEN~~~</username>`, because that value tells the platform that you're using a token. Set your token in <password>ACCESS_TOKEN</password>.
 
 == Consume an Exchange Asset with Maven
 

--- a/modules/ROOT/pages/to-publish-assets-maven.adoc
+++ b/modules/ROOT/pages/to-publish-assets-maven.adoc
@@ -195,7 +195,7 @@ https://anypoint.mulesoft.com/accounts/api/profile
 ----
 
 [IMPORTANT]
-The value in `<username>` is a literal, don't change it, because that value tells the platform that you're using a token. Set your token in <password>ACCESS_TOKEN</password>.
+The value in `<username>` is a literal, don't change it. The value tells the platform that you're using a token. Set your token in <password>ACCESS_TOKEN</password>.
 
 == Consume an Exchange Asset with Maven
 

--- a/modules/ROOT/pages/to-publish-assets-maven.adoc
+++ b/modules/ROOT/pages/to-publish-assets-maven.adoc
@@ -195,7 +195,7 @@ https://anypoint.mulesoft.com/accounts/api/profile
 ----
 
 [IMPORTANT]
-Do not change `<username>~~~TOKEN~~~</username>`, because that value tells the platform that you're using a token. Set your token in <password>ACCESS_TOKEN</password>.
+The value in `<username>` is a literal, don't change it, because that value tells the platform that you're using a token. Set your token in <password>ACCESS_TOKEN</password>.
 
 == Consume an Exchange Asset with Maven
 


### PR DESCRIPTION
Several customers faced an issue when publishing federated assets, they were replacing ~~~Token~~~ instead of the ACCESS_TOKEN in the tag:     <password>ACCESS_TOKEN</password>