### PR TITLE
DOCS-4113 REST Connect: no custom TLS connectors

### DIFF
--- a/modules/ROOT/pages/to-deploy-using-rest-connect.adoc
+++ b/modules/ROOT/pages/to-deploy-using-rest-connect.adoc
@@ -8,6 +8,8 @@ The Exchange backend uses REST Connect to transparently convert a REST API speci
 
 The Anypoint Exchange Download button lets you download the Mule 3 or Mule 4 Connector. 
 
+REST Connect does not currently support custom TLS configurations.
+
 == Access Generated Connectors
 
 In Exchange, you can download the Mule 3 or Mule 4 connector from the Download menu:


### PR DESCRIPTION
DOCS-4113 REST Connect doesn't currently support custom TLS configurations. Also goes with SE-10241 .