### PR TITLE
we need more details and better title for this document

### DIFF
--- a/modules/ROOT/pages/portal-vanity-domain.adoc
+++ b/modules/ROOT/pages/portal-vanity-domain.adoc
@@ -1,10 +1,10 @@
-= Public Portal Vanity Domain
+= How to customize Exchange Portal DNS record
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images/
 
-This document contains instructions and the necessary NGINX configuration for setting up an organization's public portal using a vanity domain.
+This document contains instructions and the necessary NGINX configuration for setting up an organization's public portal using a vanity domain (your own custom domain instead of https://anypoint.mulesoft.com/exchange) by setting up a reverse proxy as described in this document.
 
 == Whitelist Your Domain
 


### PR DESCRIPTION
It's a valuable document and very useful, we need more details and better title for this document that covers what customer will get out of it in simpler terms. the main reason is customer and support couldn't locate it is the title "portal vanity domain" we can use something more straightforward like "How to customize Exchange Portal DNS record" and then add little details to the top of the document.  
Related support ticket:
https://na29.salesforce.com/50034000018IaPV