### PR TITLE
Update to-create-an-asset.adoc

### DIFF
--- a/modules/ROOT/pages/to-create-an-asset.adoc
+++ b/modules/ROOT/pages/to-create-an-asset.adoc
@@ -62,7 +62,7 @@ A custom asset lets you share information about any aspect of your organization 
 *Note:* Exchange only permits the following file types as the optional file in a Custom asset:
 
 Images: `.jpg, .jpeg, .png, .gif, .svg` +
-Documents: `.doc, .docx, .pdf, .ppt, .pptx, .rtf, .vsd, .vsdx, .vss, .vsdx` +
+Documents: `.docx, .pdf, .pptx, .rtf, .vsdx, .vssx` +
 Compressed files: `.zip, .tgz, .jar, .gz, .7z` +
 Text files: `.txt, .json, .raml, .yaml, .yml, .md, .csv, .xml, .xsd, .wsdl, .html, .pom, .log, .sql`
 


### PR DESCRIPTION
Remove pre 2007 Microsoft Office documents from allowed documents.

Note that these formats were already being rejected when creating a Custom Asset in Exchange as they are incorrectly interpreted as `msi` files. This is also the reason we are cutting support for those formats (we are unable to reliably differentiate between those file formats).

I also modified `vsdx` to `vssx`, as it was duplicated, most likely from a typo.

Related to mulesoft/exchange-custom-assets-facade-service#219