### PR TITLE
Add resource restrictions

### DIFF
--- a/modules/ROOT/pages/to-manage-asset-portal-resources.adoc
+++ b/modules/ROOT/pages/to-manage-asset-portal-resources.adoc
@@ -4,7 +4,10 @@ include::_attributes.adoc[]
 endif::[]
 :imagesdir: ../assets/images/
 
-You can upload up to 100 resources to an asset portal. Each image is one resource. Attempting to add more will result in an error. You can delete resources to reduce the number and then add more up to the limit.
+You can upload up to 100 resources to an asset portal. Attempting to add more will result in an error. You can delete resources to reduce the number and then add more up to the limit.
+
+Only image resources can be uploaded to assset portals. Allowed image formats are: `bmp`, `gif`, `ico`, `jpe`, `jpeg`, `jpg`, `png`, `svg`, `tif`, `tiff`, or `webp`.
+
 
 These examples show how to list, retrieve, and delete resources from an asset portal with the Exchange Experience API.
 
@@ -51,4 +54,4 @@ With:
     groupId: The asset's groupId
     assetId: The asset's assetId
     version: The asset's version
-    resourceId: The image file name.
+    resourceId: The resource file name.


### PR DESCRIPTION
- Replaced `image` for `resource` when talking about resources generally.
- Added a paragraph stating that only images can be uploaded as resources.