### PR TITLE
Update publish assets to Exchange doc

### DIFF
--- a/modules/ROOT/pages/to-publish-assets-maven.adoc
+++ b/modules/ROOT/pages/to-publish-assets-maven.adoc
@@ -178,7 +178,7 @@ For the EU, the share URL is:
 https://eu1.anypoint.mulesoft.com/exchange/api/v1/assets/ORGANIZATION_ID/ASSET_ID
 ----
 
-== Publish Federated Assets
+== Publish and consume Federated Assets
 
 . xref:access-management::saml-bearer-token.adoc[Get an API bearer token by using a SAML assertion].
 +

--- a/modules/ROOT/pages/to-publish-assets-maven.adoc
+++ b/modules/ROOT/pages/to-publish-assets-maven.adoc
@@ -178,7 +178,7 @@ For the EU, the share URL is:
 https://eu1.anypoint.mulesoft.com/exchange/api/v1/assets/ORGANIZATION_ID/ASSET_ID
 ----
 
-== Publish and consume Federated Assets
+== Publish and Consume Federated Assets
 
 . xref:access-management::saml-bearer-token.adoc[Get an API bearer token by using a SAML assertion].
 +


### PR DESCRIPTION
Currently, there's a section regarding publishing federated access. That procedure is also necessary when trying to consume federated assets, so it needs to be updated to indicate that it's the same procedure.