### PR TITLE
remove vimeo from video embed options

### DIFF
--- a/modules/ROOT/pages/to-describe-an-asset.adoc
+++ b/modules/ROOT/pages/to-describe-an-asset.adoc
@@ -149,12 +149,6 @@ clipboard. Then after you log back in, you can paste the content back into the p
 +
 * Insert a YouTube video: `+![linkname](https://www.youtube.com/embed/YOUR_YOUTUBE_ID_HERE)+` +
 For example: `+![](https://www.youtube.com/embed/K3tuHUZ1J04)+`
-+
-* Insert a Vimeo video: `[linkname](VIMEO_URL)`
-* Add the asset ID to a youtu.be URL: +
-Change: `+https://youtu.be/EhJM1GawQec+` +
-To: `+![](https://www.youtube.com/embed/EhJM1GawQec)+`
-
 
 == See Also
 


### PR DESCRIPTION
Vimeo links are not supported in Exchange portals (I'm not even sure they even did work at some point). We should remove them from the documentation.