### PR TITLE
removed extra box

### DIFF
--- a/modules/ROOT/pages/add-policy-implementation-files-to-published-policy-definition.adoc
+++ b/modules/ROOT/pages/add-policy-implementation-files-to-published-policy-definition.adoc
@@ -21,5 +21,3 @@ Exchange generates the group ID, asset ID, and version. You can change these val
 . Click *Add implementation*.
 +
 The implementation displays in the *Manage implementations* table. From this table, manage the implementation versions of a policy asset. See xref:manage-versions.adoc[Manage Versions] for more information.
-
-----


### PR DESCRIPTION
there is an extra box at the bottom of the content of https://docs.mulesoft.com/exchange/add-policy-implementation-files-to-published-policy-definition. This PR is to remove that box.