### PR TITLE
W-11816228 Fix categories endpoint for Exchange tags

### DIFF
--- a/modules/ROOT/pages/exchange-api.adoc
+++ b/modules/ROOT/pages/exchange-api.adoc
@@ -335,7 +335,7 @@ The following example uses a previously created category with the name `apiType`
 [source,console]
 ----
 curl -X PUT \
-https://anypoint.mulesoft.com/exchange/api/v2/assets/:groupId/:assetId/:version/tags/managed/apiType \
+https://anypoint.mulesoft.com/exchange/api/v2/assets/:groupId/:assetId/:version/tags/categories/apiType \
   -H 'Authorization: bearer ANYPOINT_TOKEN' \
   -H 'Content-Type: application/json' \
   -d '{


### PR DESCRIPTION
Fixes endpoint for updating categories in Exchange. Correct endpoint is documented [here](https://anypoint.mulesoft.com/exchange/portals/anypoint-platform/f1e97bc6-315a-4490-82a7-23abe036327a.anypoint-platform/exchange-experience-api/minor/2.1/console/method/%233946/)

