### PR TITLE
W-18147360 add clarification for the Contains operator

### DIFF
--- a/modules/ROOT/pages/to-find-info.adoc
+++ b/modules/ROOT/pages/to-find-info.adoc
@@ -100,7 +100,7 @@ Custom fields use the following data types:
 |List of strings |Contains and not contains 
 |===
 
-*Note:* The "Contains" and "Not contains" operators check whether a specific value exactly matches an item in an enum or list-based field assigned to an asset. These operators perform a full match, not a partial match. Example: The value "Prod1" is contained in the list of Environments ["Prod1", "Prod2", "Prod3"], the value "Prod" is not contained in the list of Environments ["Prod1", "Prod2", "Prod3"].
+NOTE: The contains and not contains operators check whether a specific value exactly matches an item in an enum or list-based field assigned to an asset. These operators perform a full match, not a partial match. For example, the value `Prod1` is contained in the list of environments (Prod1, Prod", and Prod3); the value `Prod` is not contained in the list of environments (Prod1, Prod2, and Prod3).
 
 Use the preset operators to filter the search results. The values of the operators can be changed and customized. For example, you can select a date from the list of the values or add a date by entering a custom date in the defined format (YYYY-MM-DD). The customized value shows in the list of options as freeform. You can add as many custom fields as you need.
 

--- a/modules/ROOT/pages/to-find-info.adoc
+++ b/modules/ROOT/pages/to-find-info.adoc
@@ -100,6 +100,8 @@ Custom fields use the following data types:
 |List of strings |Contains and not contains 
 |===
 
+*Note:* The Contains and Not contains operators are interpreted as the filter value being contained (or not contained) in the enum or list-based field value assigned to an asset. It does not imply a partial match of the enum or list-based field values assiged to an asset. Example: the value "Prod1" is contained in the list of Environments ["Pord1", "Pord2", "Prod3"], the value "Prod" is not contained in the list of Environments ["Pord1", "Pord2", "Prod3"].
+
 Use the preset operators to filter the search results. The values of the operators can be changed and customized. For example, you can select a date from the list of the values or add a date by entering a custom date in the defined format (YYYY-MM-DD). The customized value shows in the list of options as freeform. You can add as many custom fields as you need.
 
 The following example shows the search filter with two custom fields:

--- a/modules/ROOT/pages/to-find-info.adoc
+++ b/modules/ROOT/pages/to-find-info.adoc
@@ -100,7 +100,7 @@ Custom fields use the following data types:
 |List of strings |Contains and not contains 
 |===
 
-*Note:* The Contains and Not contains operators are interpreted as the filter value being contained (or not contained) in the enum or list-based field value assigned to an asset. It does not imply a partial match of the enum or list-based field values assiged to an asset. Example: the value "Prod1" is contained in the list of Environments ["Pord1", "Pord2", "Prod3"], the value "Prod" is not contained in the list of Environments ["Pord1", "Pord2", "Prod3"].
+*Note:* The "Contains" and "Not contains" operators check whether a specific value exactly matches an item in an enum or list-based field assigned to an asset. These operators perform a full match, not a partial match. Example: The value "Prod1" is contained in the list of Environments ["Prod1", "Prod2", "Prod3"], the value "Prod" is not contained in the list of Environments ["Prod1", "Prod2", "Prod3"].
 
 Use the preset operators to filter the search results. The values of the operators can be changed and customized. For example, you can select a date from the list of the values or add a date by entering a custom date in the defined format (YYYY-MM-DD). The customized value shows in the list of options as freeform. You can add as many custom fields as you need.
 


### PR DESCRIPTION
This update is based on the following Investigation: [W-18083497](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002BJAl2YAH/view). According to Vitalii Mykytenko 99.9% of users interpret the "Contains" operator as a way to do partial matches on enum and list-based custom field values, so a clarification and example is added to avoid the confusion.


# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
