### PR TITLE
W-21553100: Update MuleSoft Help Center links to Salesforce Help

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -110,4 +110,4 @@ To download files from Japan or Canada control planes, use these URLs:
 * xref:anypoint-code-builder::af-agent-networks.adoc[Agent Network Projects]
 * xref:release-notes::exchange/anypoint-exchange-release-notes.adoc[Anypoint Exchange Release Notes]
 * https://trailhead.salesforce.com/trailblazer-community/neighborhoods/mulesoft[MuleSoft Forum]
-* https://help.mulesoft.com[MuleSoft Help Center]
+* https://help.salesforce.com[Salesforce Help]


### PR DESCRIPTION
Updates all "https://help.mulesoft.com[MuleSoft Help Center]" references to "https://help.salesforce.com[Salesforce Help]" and removes the ^ from link text.