### PR TITLE
W-23365932: Add Australia Cloud to Anypoint Exchange docs

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -92,16 +92,17 @@ Using multiple languages with Unicode is supported fully throughout Exchange and
 
 [[exchange-on-control-planes]]
 == Anypoint Exchange on Control Planes
-All features of Anypoint Exchange are supported Canada, Japan, and India control planes with these exceptions:
+All features of Anypoint Exchange are supported Canada, Japan, India, and Australia control planes with these exceptions:
 
 * xref:usage-and-engagement-metrics.adoc[Usage and engagement metrics] aren't supported.
 * Amazon CloudFront isn't configured on control planes. 
 +
-To download files from Canada, Japan, or India control planes, use these URLs:
+To download files from Canada, Japan, India, or Australia control planes, use these URLs:
 
 ** Canada S3 Bucket URL: +https://exchange-asset-manager-d1937357035a847d2ec3.s3.ca-central-1.amazonaws.com+
 ** Japan S3 Bucket URL: +https://exchange-asset-manager-bf62561aafed7e20740f.s3.ap-northeast-1.amazonaws.com+
 ** India S3 Bucket URL: +https://exchange-asset-manager-a2e86fbaee6d85765a10.s3.ap-south-1.amazonaws.com+
+** Australia S3 Bucket URL: +https://exchange-asset-manager-<placeholder>.s3.ap-southeast-2.amazonaws.com+
 
 
 == See Also


### PR DESCRIPTION
## Summary

Replicates India Cloud changes from PR #357 for Australia Cloud (`au1.platform.mulesoft.com`).

- **`index.adoc`**: Updated the control planes intro sentence to include Australia. Updated the S3 download URL list intro to include Australia. Added Australia S3 Bucket URL.

## Notes

- Australia S3 Bucket URL uses a placeholder (`<placeholder>`) — the actual bucket ID is TBD. Update before publishing.