### PR TITLE
W-23515994 Rename Flex Gateway to Omni Gateway in customer-facing text

### DIFF
--- a/modules/ROOT/pages/mcp-scanners.adoc
+++ b/modules/ROOT/pages/mcp-scanners.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-MCP server scanners connect external MCP server gateways to Anypoint Platform. They discover, catalog, and sync MCP servers from third‑party platforms into Exchange, apply governance rulesets across gateways, optionally front external endpoints with Flex Gateway, and support guided migrations to bring external APIs under Anypoint management. 
+MCP server scanners connect external MCP server gateways to Anypoint Platform. They discover, catalog, and sync MCP servers from third‑party platforms into Exchange, apply governance rulesets across gateways, optionally front external endpoints with Omni Gateway, and support guided migrations to bring external APIs under Anypoint management. 
 
 These are the supported MCP server scanners:
 


### PR DESCRIPTION
## Summary
Renames customer-facing mentions of "Flex Gateway" to "Omni Gateway" in MCP scanner documentation.

## Changes
- Updated MCP scanner overview to use "Omni Gateway" instead of "Flex Gateway"

## Test plan
- [ ] Review changes to ensure all customer-facing text has been updated
- [ ] Verify documentation builds successfully
- [ ] Confirm no broken links or references

🤖 Generated with [Claude Code](https://claude.com/claude-code)