### PR TITLE
W-23748914: Add United Kingdom Cloud to Anypoint Exchange docs

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -92,17 +92,18 @@ Using multiple languages with Unicode is supported fully throughout Exchange and
 
 [[exchange-on-control-planes]]
 == Anypoint Exchange on Control Planes
-All features of Anypoint Exchange are supported Canada, Japan, India, and Australia control planes with these exceptions:
+All features of Anypoint Exchange are supported Canada, Japan, India, Australia, and United Kingdom control planes with these exceptions:
 
 * xref:usage-and-engagement-metrics.adoc[Usage and engagement metrics] aren't supported.
 * Amazon CloudFront isn't configured on control planes. 
 +
-To download files from Canada, Japan, India, or Australia control planes, use these URLs:
+To download files from Canada, Japan, India, Australia, or United Kingdom control planes, use these URLs:
 
 ** Canada S3 Bucket URL: +https://exchange-asset-manager-d1937357035a847d2ec3.s3.ca-central-1.amazonaws.com+
 ** Japan S3 Bucket URL: +https://exchange-asset-manager-bf62561aafed7e20740f.s3.ap-northeast-1.amazonaws.com+
 ** India S3 Bucket URL: +https://exchange-asset-manager-a2e86fbaee6d85765a10.s3.ap-south-1.amazonaws.com+
 ** Australia S3 Bucket URL: +https://exchange-asset-manager-<placeholder>.s3.ap-southeast-2.amazonaws.com+
+** United Kingdom S3 Bucket URL: +https://exchange-asset-manager-<placeholder>.s3.eu-west-2.amazonaws.com+
 
 
 == See Also


### PR DESCRIPTION
## Summary

Replicates the Australia Cloud changes from PR #381 for United Kingdom Cloud (`gb1.platform.mulesoft.com`).

- **`index.adoc`**: Updated the control planes intro sentence and S3 download URL intro to include United Kingdom; added the United Kingdom S3 Bucket URL.

## Notes

- **United Kingdom S3 bucket ID is unknown** — using placeholder (`exchange-asset-manager-<placeholder>.s3.eu-west-2.amazonaws.com`). Update before publishing.

Made with [Cursor](https://cursor.com)